### PR TITLE
Keepalived virtual router ID

### DIFF
--- a/defaults/openstack/ha.pan
+++ b/defaults/openstack/ha.pan
@@ -8,6 +8,7 @@ variable OS_RABBITMQ_CLUSTER_SECRET ?= if (OS_HA) {error('OS_RABBITMQ_CLUSTER_SE
 variable OS_RABBITMQ_HOSTS ?= if (OS_HA) {error('OS_RABBITMQ_HOSTS must be set for high availability');} else {null;};
 variable OS_MEMCACHE_HOSTS ?= if (OS_HA) {error('OS_MEMCACHE_HOSTS must be set for high availability');} else {null;};
 variable OS_FLOATING_IP ?= if (OS_HA) {error('OS_FLOATING_IP must be set for high availability');} else {null;};
+variable OS_KEEPALIVED_ROUTER_ID ?= if (OS_HA) {error('OS_FLOATING_IP must be set for high availability');} else {null;};
 variable OS_LOADBALANCER_MASTER ?= if (OS_HA) {error('OS_LOADBALANCER_MASTER must be set for high availability');} else {null;};
 variable OS_SERVERS ?= if (OS_HA) {error('OS_SERVERS must be set for high availability');} else {null;};
 variable OS_KEYSTONE_SERVERS ?= if (OS_HA) {OS_SERVERS;} else {null;};

--- a/defaults/openstack/haproxy.pan
+++ b/defaults/openstack/haproxy.pan
@@ -13,7 +13,7 @@ prefix '/software/components/metaconfig/services/{/usr/local/bin/haproxy-reload}
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = if (length(OS_NOVA_SERVERS) != 0) {append(dict('name' , 'nova-osapi',
+'contents/vhosts/' = append(if (length(OS_NOVA_SERVERS) != 0) {dict('name' , 'nova-osapi',
     'port' , OS_NOVA_OSAPI_PORT,
     'bind' ,  '*:'+to_string(OS_NOVA_OSAPI_PORT),
     'config' , dict(
@@ -29,9 +29,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NOVA_SERVERS,)
-    };
+    }
 );
-'contents/vhosts/' = if (length(OS_NOVA_SERVERS) != 0) {append(dict('name' , 'nova-ec2',
+'contents/vhosts/' = append(if (length(OS_NOVA_SERVERS) != 0) {dict('name' , 'nova-ec2',
     'port' , OS_NOVA_EC2_PORT,
     'bind' ,  '*:'+to_string(OS_NOVA_EC2_PORT),
     'config' , dict(
@@ -47,9 +47,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NOVA_SERVERS,)
-    };
+    }
 );
-'contents/vhosts/' = if (length(OS_NOVA_SERVERS) != 0) {append(dict('name' , 'nova-metadata',
+'contents/vhosts/' = append(if (length(OS_NOVA_SERVERS) != 0) {dict('name' , 'nova-metadata',
     'port' , OS_NOVA_METADATA_PORT,
     'bind' ,  '*:'+to_string(OS_NOVA_METADATA_PORT),
     'config' , dict(
@@ -65,9 +65,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NOVA_SERVERS,)
-    };
+    }
 );
-'contents/vhosts/' = if (length(OS_NOVA_SERVERS) != 0) {append(dict('name' , 'nova-novnc',
+'contents/vhosts/' = append(if (length(OS_NOVA_SERVERS) != 0) {dict('name' , 'nova-novnc',
     'port' , OS_NOVA_NOVNC_PORT,
     'bind' ,  '*:'+to_string(OS_NOVA_NOVNC_PORT),
     'config' , dict(
@@ -83,7 +83,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NOVA_SERVERS,)
-    };
+    }
 );
 
 ########
@@ -92,7 +92,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = if (length(OS_NEUTRON_SERVERS) != 0) {append(dict('name' , 'neutron',
+'contents/vhosts/' = append(if (length(OS_NEUTRON_SERVERS) != 0) {dict('name' , 'neutron',
     'port' , OS_NEUTRON_PORT,
     'bind' ,  '*:'+to_string(OS_NEUTRON_PORT),
     'config' , dict(
@@ -108,12 +108,12 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NEUTRON_SERVERS,)
-    };
+    }
 );
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = if (length(OS_NEUTRON_SERVERS) != 0) {append(dict('name' , 'neutron-metadata',
+'contents/vhosts/' = append(if (length(OS_NEUTRON_SERVERS) != 0) {dict('name' , 'neutron-metadata',
     'port' , OS_NEUTRON_METADATA_PORT,
     'bind' ,  '*:'+to_string(OS_NEUTRON_METADATA_PORT),
     'config' , dict(
@@ -129,7 +129,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NEUTRON_SERVERS,)
-    };
+    }
 );
 
 
@@ -140,7 +140,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = if (length(OS_KEYSTONE_SERVERS) != 0) {append(dict('name' , 'keystone',
+'contents/vhosts/' = append(if (length(OS_KEYSTONE_SERVERS) != 0) {dict('name' , 'keystone',
     'port' , OS_KEYSTONE_PORT,
     'bind' ,  '*:'+to_string(OS_KEYSTONE_PORT),
     'config' , dict(
@@ -156,9 +156,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_KEYSTONE_SERVERS,)
-    };
+    }
 );
-'contents/vhosts/' = if (length(OS_KEYSTONE_SERVERS) != 0) {append(dict('name' , 'keystone-admin',
+'contents/vhosts/' = append(if (length(OS_KEYSTONE_SERVERS) != 0) {dict('name' , 'keystone-admin',
     'port' , OS_KEYSTONE_ADMIN_PORT,
     'bind' , '*:'+to_string(OS_KEYSTONE_ADMIN_PORT),
     'config' , dict(
@@ -174,7 +174,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_KEYSTONE_SERVERS,)
-    };
+    }
 );
 
 
@@ -184,7 +184,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = if (length(OS_CINDER_SERVERS) != 0) {append(dict('name' , 'cinder',
+'contents/vhosts/' = append(if (length(OS_CINDER_SERVERS) != 0) {dict('name' , 'cinder',
     'port' , OS_CINDER_PORT,
     'bind' ,  '*:'+to_string(OS_CINDER_PORT),
     'config' , dict(
@@ -200,7 +200,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_CINDER_SERVERS,)
-    };
+    }
 );
 
 ########
@@ -209,7 +209,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = if (length(OS_GLANCE_SERVERS) != 0) {append(dict('name' , 'glance',
+'contents/vhosts/' = append(if (length(OS_GLANCE_SERVERS) != 0) {dict('name' , 'glance',
     'port' , OS_GLANCE_PORT,
     'bind' ,  '*:'+to_string(OS_GLANCE_PORT),
     'config' , dict(
@@ -225,7 +225,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_GLANCE_SERVERS,)
-    };
+    }
 );
 
 
@@ -235,7 +235,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = if (length(OS_HORIZON_SERVERS) != 0) {append(dict('name' , 'horizon',
+'contents/vhosts/' = append(if (length(OS_HORIZON_SERVERS) != 0) {dict('name' , 'horizon',
     'port' , OS_HORIZON_PORT,
     'bind' , '*:'+to_string(OS_HORIZON_PORT),
     'config' , dict(
@@ -258,7 +258,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
        'cookie','control',
     ),
     'servers', OS_HORIZON_SERVERS,)
-    };
+    }
 );
 
 ########
@@ -268,7 +268,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = if (length(OS_HEAT_SERVERS) != 0) {append(dict('name' , 'heat-cfn',
+'contents/vhosts/' = append(if (length(OS_HEAT_SERVERS) != 0) {dict('name' , 'heat-cfn',
     'port' , OS_HEAT_CFN_PORT,
     'bind' ,  '*:'+to_string(OS_HEAT_CFN_PORT),
     'config' , dict(
@@ -284,9 +284,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_HEAT_SERVERS,)
-    };
+    }
 );
-'contents/vhosts/' = if (length(OS_HEAT_SERVERS) != 0) {append(dict('name' , 'heat',
+'contents/vhosts/' = append(if (length(OS_HEAT_SERVERS) != 0) {dict('name' , 'heat',
     'port' , OS_HEAT_PORT,
     'bind' , '*:'+to_string(OS_HEAT_PORT),
     'config' , dict(
@@ -302,7 +302,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_HEAT_SERVERS,)
-    };
+    }
 );
 
 
@@ -313,7 +313,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = if (length(OS_CEILOMETER_SERVERS) != 0) {append(dict('name' , 'ceilometer',
+'contents/vhosts/' = append(if (length(OS_CEILOMETER_SERVERS) != 0) {dict('name' , 'ceilometer',
     'port' , OS_CEILOMETER_PORT,
     'bind' ,  '*:'+to_string(OS_CEILOMETER_PORT),
     'config' , dict(
@@ -329,5 +329,5 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_CEILOMETER_SERVERS,)
-    };
+    }
 );

--- a/defaults/openstack/haproxy.pan
+++ b/defaults/openstack/haproxy.pan
@@ -13,7 +13,7 @@ prefix '/software/components/metaconfig/services/{/usr/local/bin/haproxy-reload}
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = append(dict('name' , 'nova-osapi',
+'contents/vhosts/' = if (length(OS_NOVA_SERVERS) != 0) {append(dict('name' , 'nova-osapi',
     'port' , OS_NOVA_OSAPI_PORT,
     'bind' ,  '*:'+to_string(OS_NOVA_OSAPI_PORT),
     'config' , dict(
@@ -29,8 +29,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NOVA_SERVERS,)
+    };
 );
-'contents/vhosts/' = append(dict('name' , 'nova-ec2',
+'contents/vhosts/' = if (length(OS_NOVA_SERVERS) != 0) {append(dict('name' , 'nova-ec2',
     'port' , OS_NOVA_EC2_PORT,
     'bind' ,  '*:'+to_string(OS_NOVA_EC2_PORT),
     'config' , dict(
@@ -46,8 +47,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NOVA_SERVERS,)
+    };
 );
-'contents/vhosts/' = append(dict('name' , 'nova-metadata',
+'contents/vhosts/' = if (length(OS_NOVA_SERVERS) != 0) {append(dict('name' , 'nova-metadata',
     'port' , OS_NOVA_METADATA_PORT,
     'bind' ,  '*:'+to_string(OS_NOVA_METADATA_PORT),
     'config' , dict(
@@ -63,8 +65,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NOVA_SERVERS,)
+    };
 );
-'contents/vhosts/' = append(dict('name' , 'nova-novnc',
+'contents/vhosts/' = if (length(OS_NOVA_SERVERS) != 0) {append(dict('name' , 'nova-novnc',
     'port' , OS_NOVA_NOVNC_PORT,
     'bind' ,  '*:'+to_string(OS_NOVA_NOVNC_PORT),
     'config' , dict(
@@ -80,6 +83,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NOVA_SERVERS,)
+    };
 );
 
 ########
@@ -88,7 +92,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = append(dict('name' , 'neutron',
+'contents/vhosts/' = if (length(OS_NEUTRON_SERVERS) != 0) {append(dict('name' , 'neutron',
     'port' , OS_NEUTRON_PORT,
     'bind' ,  '*:'+to_string(OS_NEUTRON_PORT),
     'config' , dict(
@@ -104,11 +108,12 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NEUTRON_SERVERS,)
+    };
 );
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = append(dict('name' , 'neutron-metadata',
+'contents/vhosts/' = if (length(OS_NEUTRON_SERVERS) != 0) {append(dict('name' , 'neutron-metadata',
     'port' , OS_NEUTRON_METADATA_PORT,
     'bind' ,  '*:'+to_string(OS_NEUTRON_METADATA_PORT),
     'config' , dict(
@@ -124,6 +129,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_NEUTRON_SERVERS,)
+    };
 );
 
 
@@ -134,7 +140,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = append(dict('name' , 'keystone',
+'contents/vhosts/' = if (length(OS_KEYSTONE_SERVERS) != 0) {append(dict('name' , 'keystone',
     'port' , OS_KEYSTONE_PORT,
     'bind' ,  '*:'+to_string(OS_KEYSTONE_PORT),
     'config' , dict(
@@ -150,8 +156,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_KEYSTONE_SERVERS,)
+    };
 );
-'contents/vhosts/' = append(dict('name' , 'keystone-admin',
+'contents/vhosts/' = if (length(OS_KEYSTONE_SERVERS) != 0) {append(dict('name' , 'keystone-admin',
     'port' , OS_KEYSTONE_ADMIN_PORT,
     'bind' , '*:'+to_string(OS_KEYSTONE_ADMIN_PORT),
     'config' , dict(
@@ -167,6 +174,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_KEYSTONE_SERVERS,)
+    };
 );
 
 
@@ -176,7 +184,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = append(dict('name' , 'cinder',
+'contents/vhosts/' = if (length(OS_CINDER_SERVERS) != 0) {append(dict('name' , 'cinder',
     'port' , OS_CINDER_PORT,
     'bind' ,  '*:'+to_string(OS_CINDER_PORT),
     'config' , dict(
@@ -192,6 +200,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_CINDER_SERVERS,)
+    };
 );
 
 ########
@@ -200,7 +209,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = append(dict('name' , 'glance',
+'contents/vhosts/' = if (length(OS_GLANCE_SERVERS) != 0) {append(dict('name' , 'glance',
     'port' , OS_GLANCE_PORT,
     'bind' ,  '*:'+to_string(OS_GLANCE_PORT),
     'config' , dict(
@@ -216,6 +225,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_GLANCE_SERVERS,)
+    };
 );
 
 
@@ -225,7 +235,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = append(dict('name' , 'horizon',
+'contents/vhosts/' = if (length(OS_HORIZON_SERVERS) != 0) {append(dict('name' , 'horizon',
     'port' , OS_HORIZON_PORT,
     'bind' , '*:'+to_string(OS_HORIZON_PORT),
     'config' , dict(
@@ -248,6 +258,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
        'cookie','control',
     ),
     'servers', OS_HORIZON_SERVERS,)
+    };
 );
 
 ########
@@ -257,7 +268,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = append(dict('name' , 'heat-cfn',
+'contents/vhosts/' = if (length(OS_HEAT_SERVERS) != 0) {append(dict('name' , 'heat-cfn',
     'port' , OS_HEAT_CFN_PORT,
     'bind' ,  '*:'+to_string(OS_HEAT_CFN_PORT),
     'config' , dict(
@@ -273,8 +284,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_HEAT_SERVERS,)
+    };
 );
-'contents/vhosts/' = append(dict('name' , 'heat',
+'contents/vhosts/' = if (length(OS_HEAT_SERVERS) != 0) {append(dict('name' , 'heat',
     'port' , OS_HEAT_PORT,
     'bind' , '*:'+to_string(OS_HEAT_PORT),
     'config' , dict(
@@ -290,7 +302,9 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_HEAT_SERVERS,)
+    };
 );
+
 
 ########
 # Ceilometer #
@@ -299,7 +313,7 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 
 prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
 'module' = 'haproxy';
-'contents/vhosts/' = append(dict('name' , 'ceilometer',
+'contents/vhosts/' = if (length(OS_CEILOMETER_SERVERS) != 0) {append(dict('name' , 'ceilometer',
     'port' , OS_CEILOMETER_PORT,
     'bind' ,  '*:'+to_string(OS_CEILOMETER_PORT),
     'config' , dict(
@@ -315,4 +329,5 @@ prefix '/software/components/metaconfig/services/{/etc/haproxy/haproxy.cfg}';
         'maxqueue', 128,
         'weight', 100,),
     'servers', OS_CEILOMETER_SERVERS,)
+    };
 );

--- a/defaults/openstack/rpms.pan
+++ b/defaults/openstack/rpms.pan
@@ -6,3 +6,4 @@ prefix '/software/packages';
 '{openstack-selinux}' ?= dict();
 '{openstack-packstack}' ?= dict();
 '{python-openstackclient}' ?= dict();
+'python-memcached' ?= dict();

--- a/features/ceilometer/ha.pan
+++ b/features/ceilometer/ha.pan
@@ -11,8 +11,7 @@ foreach(k;v;OS_MEMCACHE_HOSTS) {
             hosts = hosts + ',' + v + ':11211';
         } else {
             hosts = v + ':11211';
-        };
-
-        hosts;
+        };  
     };
+    hosts;
 };

--- a/features/cinder/controller/ha.pan
+++ b/features/cinder/controller/ha.pan
@@ -13,7 +13,6 @@ foreach(k;v;OS_MEMCACHE_HOSTS) {
         } else {
             hosts = v + ':11211';
         };
-
-        hosts;
     };
+    hosts;
 };

--- a/features/dashboard/config.pan
+++ b/features/dashboard/config.pan
@@ -31,7 +31,7 @@ prefix '/software/components/metaconfig/services/{/etc/openstack-dashboard/local
 'contents/keystone/api_version' = OS_HORIZON_KEYSTONE_API_VERSION;
 'contents/keystone/port' = 5000;
 'contents/secret_key' = OS_HORIZON_SECRET_KEY;
-'contents/memcacheservers' = list('127.0.0.1:11211');
+'contents/memcacheservers' = '127.0.0.1:11211';
 
 include if (OS_HA) {
     'features/dashboard/ha';

--- a/features/dashboard/config.pan
+++ b/features/dashboard/config.pan
@@ -31,6 +31,7 @@ prefix '/software/components/metaconfig/services/{/etc/openstack-dashboard/local
 'contents/keystone/api_version' = OS_HORIZON_KEYSTONE_API_VERSION;
 'contents/keystone/port' = 5000;
 'contents/secret_key' = OS_HORIZON_SECRET_KEY;
+'contents/memcacheservers' = list('127.0.0.1:11211');
 
 include if (OS_HA) {
     'features/dashboard/ha';

--- a/features/dashboard/ha.pan
+++ b/features/dashboard/ha.pan
@@ -1,1 +1,15 @@
 template features/dashboard/ha;
+
+include 'components/metaconfig/config';
+prefix '/software/components/metaconfig/services/{/etc/openstack-dashboard/local_settings}';
+'module' = 'openstack/django-horizon';
+'contents/memcacheservers' = { hosts = '';
+foreach(k;v;OS_MEMCACHE_HOSTS) {
+        if ( hosts != '') {
+            hosts = hosts + ',' + v + ':11211';
+        } else {
+            hosts = v + ':11211';
+        };
+        hosts;
+    };
+};

--- a/features/dashboard/metaconfig/django-horizon.tt
+++ b/features/dashboard/metaconfig/django-horizon.tt
@@ -34,7 +34,7 @@ SECRET_KEY='[% secret_key %]'
 CACHES = {
     'default': {
          'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-         'LOCATION': '127.0.0.1:11211',
+         'LOCATION': '[% memcacheservers %]',
     }
 }
 

--- a/features/glance/ha.pan
+++ b/features/glance/ha.pan
@@ -13,9 +13,8 @@ foreach(k;v;OS_MEMCACHE_HOSTS) {
         } else {
             hosts = v + ':11211';
         };
-
-        hosts;
     };
+    hosts;
 };
 
 # Configuration file for glance
@@ -30,7 +29,6 @@ foreach(k;v;OS_MEMCACHE_HOSTS) {
         } else {
             hosts = v + ':11211';
         };
-
-        hosts;
     };
+    hosts;
 };

--- a/features/keystone/config.pan
+++ b/features/keystone/config.pan
@@ -45,9 +45,8 @@ foreach(k;v;OS_MEMCACHE_HOSTS) {
         } else {
             hosts = v + ':11211';
         };
-
-        hosts;
     };
+    hosts;
 };
 
 # [revoke] section

--- a/features/neutron/controller/ha.pan
+++ b/features/neutron/controller/ha.pan
@@ -13,9 +13,8 @@ foreach(k;v;OS_MEMCACHE_HOSTS) {
         } else {
             hosts = v + ':11211';
         };
-
-        hosts;
     };
+    hosts;
 };
 'contents/DEFAULT/dhcp_agents_per_network' = 2;
 'contents/DEFAULT/allow_automatic_l3agent_failover' = 'True';

--- a/features/nova/controller/ha.pan
+++ b/features/nova/controller/ha.pan
@@ -12,9 +12,8 @@ foreach(k;v;OS_MEMCACHE_HOSTS) {
         } else {
             hosts = v + ':11211';
         };
-
-        hosts;
     };
+    hosts;
 };
 
 # [vnc] section

--- a/features/rabbitmq/config.pan
+++ b/features/rabbitmq/config.pan
@@ -1,6 +1,5 @@
 unique template features/rabbitmq/config;
 
-
 include 'features/rabbitmq/rpms/config';
 
 include 'components/chkconfig/config';

--- a/personality/keepalived/config.pan
+++ b/personality/keepalived/config.pan
@@ -4,7 +4,7 @@ unique template personality/keepalived/config;
 variable FLOATING_IPS ?= list(
     dict("name", "Openstack",
         "master", OS_LOADBALANCER_MASTER,
-        "router_id", 52,
+        "router_id", OS_KEEPALIVED_ROUTER_ID,
         "ip", OS_FLOATING_IP),
 );
 


### PR DESCRIPTION
Allows the Virtual Router for Keepalived to be changed to allow multiple keepalived instances to exists within a deployment
