### PR TITLE
Fix OS_MEMCACHE_HOSTS variable name

### DIFF
--- a/defaults/openstack/config.pan
+++ b/defaults/openstack/config.pan
@@ -107,7 +107,7 @@ variable OS_KEYSTONE_PORTS ?= list(OS_KEYSTONE_PORT,OS_KEYSTONE_ADMIN_PORT);
 #############################
 # Memcache specfic variable #
 #############################
-variable OS_MEMCACHE_HOSTs ?= list('localhost');
+variable OS_MEMCACHE_HOSTS ?= list('localhost');
 
 #############################
 # MongoDB specfic variable #


### PR DESCRIPTION
There was a typo issue on OS_MEMCACHED_HOSTS variable name
