### PR TITLE
Improve CEPH backend support

### DIFF
--- a/defaults/openstack/config.pan
+++ b/defaults/openstack/config.pan
@@ -236,6 +236,8 @@ variable OS_METADATA_HOST ?= OS_NOVA_CONTROLLER_HOST;
 # CEPH Specific Variables #
 ###########################
 variable OS_CEPH ?= false;
+variable OS_CEPH_NOVA ?= OS_CEPH;
+variable OS_CEPH_GLANCE ?= OS_CEPH;
 variable OS_CEPH_GLANCE_POOL ?= 'images';
 variable OS_CEPH_GLANCE_USER ?= 'glance';
 variable OS_CEPH_GLANCE_CEPH_CONF ?= '/etc/ceph/ceph.conf';

--- a/defaults/openstack/config.pan
+++ b/defaults/openstack/config.pan
@@ -107,7 +107,7 @@ variable OS_KEYSTONE_PORTS ?= list(OS_KEYSTONE_PORT,OS_KEYSTONE_ADMIN_PORT);
 #############################
 # Memcache specfic variable #
 #############################
-variable OS_MEMCACHE_HOSTs ?= list('localhost');
+variable OS_MEMCACHE_HOSTS ?= list('localhost');
 
 #############################
 # MongoDB specfic variable #

--- a/features/glance/config.pan
+++ b/features/glance/config.pan
@@ -95,7 +95,7 @@ prefix '/software/components/metaconfig/services/{/etc/glance/glance-registry.co
 # [paste_deploy] section
 'contents/paste_deploy/flavor' = 'keystone';
 
-include if (OS_CEPH) {
+include if (OS_CEPH_GLANCE) {
     'features/glance/ceph';
 } else {
     'features/glance/file';

--- a/features/nova/compute/config.pan
+++ b/features/nova/compute/config.pan
@@ -85,7 +85,7 @@ prefix '/software/components/metaconfig/services/{/etc/nova/nova.conf}';
   };
 };
 
-include if (OS_CEPH) {
+include if (OS_CEPH_NOVA) {
     'features/nova/compute/ceph';
 } else {
     null;


### PR DESCRIPTION
By default, OS_CEPH enable Ceph for each Ceph-able services (cinder / glance / nova for system disk)

I add OS_CEPH_NOVA and OS_CEPH_GLANCE to control Ceph configuration for nova system disk and glance image location.
