### PR TITLE
Add mongodb user as kept_users

### DIFF
--- a/features/accounts/config.pan
+++ b/features/accounts/config.pan
@@ -47,3 +47,6 @@ prefix '/software/components/accounts';
 # MongoDB user
 'kept_users/mongod' = '';
 'kept_groups/mongod' = '';
+'kept_users/mongodb' = '';
+'kept_groups/mongodb' = '';
+


### PR DESCRIPTION
Depends of mongodb RPM version (v2 or v3) the associated user is mongod or mongodb. To avoid some misconfiguration I propose to add both as kept_users.
