### PR TITLE
Revert "Add mongodb user as kept_users"

### DIFF
--- a/features/accounts/config.pan
+++ b/features/accounts/config.pan
@@ -47,6 +47,3 @@ prefix '/software/components/accounts';
 # MongoDB user
 'kept_users/mongod' = '';
 'kept_groups/mongod' = '';
-'kept_users/mongodb' = '';
-'kept_groups/mongodb' = '';
-


### PR DESCRIPTION
Reverts quattor/template-library-openstack#30 who [comment](https://github.com/quattor/template-library-openstack/pull/30#issuecomment-251667865) was not addressed... As said, this is not the right place to add this. It should be added in `ncm-account` as it should be the default behaviour for any installation of mongodb and it should probably be added to the OS base.pan template as it makes easier to deploy this change before the next release of Quattor and is a good catch all in case of somebody using the templates without upgrading the component.

My remark also applies to other protected groups/users embedded in openstack templates.
