### PR TITLE
Fix ceilometer config to add mongodb configuration

### DIFF
--- a/defaults/openstack/config.pan
+++ b/defaults/openstack/config.pan
@@ -114,6 +114,15 @@ variable OS_MEMCACHE_HOSTS ?= list('localhost');
 #############################
 variable OS_MONGODB_VERSION ?= 2;
 variable OS_MONGODB_DBPATH ?= '/var/mongodb';
+@use {
+  type = string
+  note = Default value depend of mongodb version. Set the unix username of mongod daemon.
+}
+variable OS_MONGODB_USER ?= if (OS_MONGODB_VERSION == 2) {
+  'mongodb';
+} else {
+  'mongod';
+};
 
 ##########################
 # Nova specific variable #

--- a/features/ceilometer/config.pan
+++ b/features/ceilometer/config.pan
@@ -12,6 +12,9 @@ include 'features/accounts/config';
 # Include utils
 include 'defaults/openstack/utils';
 
+# Include mongodb configuration
+include 'features/mongodb/config';
+
 include 'features/ceilometer/rpms/config';
 
 include 'components/chkconfig/config';

--- a/features/mongodb/config.pan
+++ b/features/mongodb/config.pan
@@ -7,7 +7,7 @@ prefix '/software/components/dirperm';
 'paths' = {
   SELF[length(SELF)] = dict(
     'path', OS_MONGODB_DBPATH,
-    'owner', 'mongod:root',
+    'owner', format('%s:root', OS_MONGODB_USER),
     'type', 'd',
     'perm', '0755',
   );

--- a/features/mongodb/mongodb2.pan
+++ b/features/mongodb/mongodb2.pan
@@ -5,7 +5,7 @@ include 'components/metaconfig/config';
 prefix '/software/components/metaconfig/services/{/etc/mongod.conf}';
 'module' = 'tiny';
 'daemons/mongod' = 'restart';
-'contents/bind_ip' = '127.0.0.1, ' + PRIMARY_IP;
+'contents/bind_ip' = '127.0.0.1,' + PRIMARY_IP;
 'contents/dbpath' = OS_MONGODB_DBPATH;
 'contents/logpath' = '/var/log/mongodb/mongod.log';
 'contents/fork' = 'true';


### PR DESCRIPTION
Hi,

By default, ceilometer feature doesn't config mongodb. I put it on features/ceilometer/config + add OS_MONGODB_USER which is compute to match the right username depending of mongodb version used.
