### PR TITLE
Add DNS_DOMAIN to OpenStack

### DIFF
--- a/defaults/openstack/config.pan
+++ b/defaults/openstack/config.pan
@@ -162,6 +162,12 @@ variable OS_NEUTRON_DEFAULT_DHCP_POOL ?= dict(
 );
 variable OS_NEUTRON_DEFAULT_GATEWAY ?= '192.168.0.1';
 variable OS_NEUTRON_DEFAULT_NAMESERVER ?= '192.168.0.1';
+@use {
+  type = string
+  default = openstacklocal
+  note = Set the domain name that will be give to virtual machine
+}
+variable OS_NEUTRON_DNS_DOMAIN ?= 'openstacklocal';
 
 
 ############################

--- a/features/neutron/network/config.pan
+++ b/features/neutron/network/config.pan
@@ -46,6 +46,7 @@ prefix '/software/components/metaconfig/services/{/etc/neutron/neutron.conf}';
 'contents/DEFAULT/base_mac' = OS_NEUTRON_BASE_MAC;
 'contents/DEFAULT/dvr_base_mac' = OS_NEUTRON_DVR_BASE_MAC;
 'contents/DEFAULT/notification_driver' = 'messagingv2';
+'contents/DEFAULT/dhcp_domain' = OS_NEUTRON_DNS_DOMAIN;
 
 # [keystone_authtoken]
 'contents/keystone_authtoken' = openstack_load_config(OS_AUTH_CLIENT_CONFIG);


### PR DESCRIPTION
Hi,

By default, DNS search on VM is openstacklocal. With this PR you will can custom this.
