### PR TITLE
Fix multi domain

### DIFF
--- a/features/keystone/identity/ldap.pan
+++ b/features/keystone/identity/ldap.pan
@@ -16,11 +16,7 @@ prefix '/software/components/metaconfig/services/{/etc/keystone/keystone.conf}';
 # All ldap configuration is put on /etc/keystone/domains/keystone.DOMAIN_NAME.conf
 prefix '/software/components/metaconfig';
 'services' = {
-  # default domain is still on SQL
-    SELF[escape('/etc/keystone/domains/keystone.default.conf')] = dict(
-              'module', 'tiny',
-    );
-    SELF[escape('/etc/keystone/domains/keystone.default.conf')]['contents']['identity'] = dict('driver', 'sql');
+  # the default identity driver for multi domain is SQL
 
     # foreach domain, populate the configuration file
     foreach(domain;params;OPENSTACK_KEYSTONE_IDENTITY_LDAP_PARAMS) {

--- a/features/keystone/identity/ldap.pan
+++ b/features/keystone/identity/ldap.pan
@@ -9,7 +9,7 @@ include 'components/metaconfig/config';
 prefix '/software/components/metaconfig/services/{/etc/keystone/keystone.conf}';
 'contents/identity/domain_specific_drivers_enabled' = 'True';
 'contents/identity/domain_config_dir' = '/etc/keystone/domains';
-'contents/identity/driver' = 'ldap';
+'contents/identity/driver' = 'sql';
 'contents/resource/driver' = 'sql';
 'contents/assignment/driver' = 'sql';
 


### PR DESCRIPTION
This new configuration allows for additional domains to be created and properly managed. This is important for components such as Heat which requires an additional domain.
 - Sets the default identity driver to be SQL
 - Removes explicit configuration for the default domain as the defaults are correct.