### PR TITLE
update db connection strings in preparation for newton upgrade

### DIFF
--- a/defaults/openstack/dicts.pan
+++ b/defaults/openstack/dicts.pan
@@ -6,7 +6,7 @@ variable OPENSTACK_GLANCE_DB = merge(SELF , dict(
     'dbname' , 'glance',
     'dbuser' , OPENSTACK_GLANCE_DB_USERNAME,
     'dbpassword' , OPENSTACK_GLANCE_DB_PASSWORD,
-    'dbprotocol' , 'mysql',
+    'dbprotocol' , 'mysql+pymysql',
     'dbport' , 3306,
 ));
 
@@ -16,7 +16,7 @@ variable OPENSTACK_HEAT_DB = merge(SELF , dict(
     'dbname' , 'heat',
     'dbuser' , OPENSTACK_HEAT_DB_USERNAME,
     'dbpassword' , OPENSTACK_HEAT_DB_PASSWORD,
-    'dbprotocol' , 'mysql',
+    'dbprotocol' , 'mysql+pymysql',
     'dbport' , 3306,
 ));
 
@@ -26,7 +26,7 @@ variable OPENSTACK_KEYSTONE_DB = merge(SELF , dict(
     'dbname' , 'keystone',
     'dbuser' , OPENSTACK_KEYSTONE_DB_USERNAME,
     'dbpassword' , OPENSTACK_KEYSTONE_DB_PASSWORD,
-    'dbprotocol' , 'mysql',
+    'dbprotocol' , 'mysql+pymysql',
     'dbport' , 3306,
 ));
 
@@ -36,7 +36,7 @@ variable OPENSTACK_NOVA_DB = merge(SELF , dict(
     'dbname' , 'nova',
     'dbuser' , OPENSTACK_NOVA_DB_USERNAME,
     'dbpassword' , OPENSTACK_NOVA_DB_PASSWORD,
-    'dbprotocol' , 'mysql',
+    'dbprotocol' , 'mysql+pymysql',
     'dbport' , 3306,
 ));
 
@@ -46,7 +46,7 @@ variable OPENSTACK_NOVA_API_DB = merge(SELF , dict(
     'dbname' , 'nova_api',
     'dbuser' , OPENSTACK_NOVA_DB_USERNAME,
     'dbpassword' , OPENSTACK_NOVA_DB_PASSWORD,
-    'dbprotocol' , 'mysql',
+    'dbprotocol' , 'mysql+pymysql',
     'dbport' , 3306,
 ));
 
@@ -56,7 +56,7 @@ variable OPENSTACK_NEUTRON_DB = merge(SELF , dict(
     'dbname' , 'neutron',
     'dbuser' , OPENSTACK_NEUTRON_DB_USERNAME,
     'dbpassword' , OPENSTACK_NEUTRON_DB_PASSWORD,
-    'dbprotocol' , 'mysql',
+    'dbprotocol' , 'mysql+pymysql',
     'dbport' , 3306,
 ));
 
@@ -66,7 +66,7 @@ variable OPENSTACK_CINDER_DB = merge(SELF , dict(
     'dbname' , 'cinder',
     'dbuser' , OPENSTACK_CINDER_DB_USERNAME,
     'dbpassword' , OPENSTACK_CINDER_DB_PASSWORD,
-    'dbprotocol' , 'mysql',
+    'dbprotocol' , 'mysql+pymysql',
     'dbport' , 3306,
 ));
 


### PR DESCRIPTION
connections are moving to mysql+pymysql from newton onwards, this is supported in mitaka